### PR TITLE
feat: fill NAs in cols level, category and color

### DIFF
--- a/src/processor.py
+++ b/src/processor.py
@@ -64,6 +64,11 @@ if __name__ == '__main__':
     df = df.merge(max_level_per_group, 
                   on=['location_id', 'datetime'], 
                   how='left')
+    
+    # Fill NAs in cos level, category and color
+    df['level'].fillna(value=-1, inplace=True)
+    df['category'].fillna(value="No Entry", inplace=True)
+    df['color'].fillna(value='#808080', inplace=True)
 
     print(df.head(10))
     df.to_csv("data/aq_data.csv")


### PR DESCRIPTION
Solve #1 

I utilized the pandas built-in fillna() method to populate missing values in the level, category, and color columns with the following defaults:

    level = -1: Represents an invalid or impossible value to clearly distinguish it from valid data.

    category = 'No Entry': A clear and human-readable placeholder.

    color = '#808080': A neutral gray tone to visually separate it from other color-coded entries.